### PR TITLE
persist to permanent system path on Set-NodeVersion

### DIFF
--- a/nvm.psm1
+++ b/nvm.psm1
@@ -61,10 +61,22 @@ function Set-NodeVersion {
         return
     }
 
+    # immediately add to the current powershell session path
     $env:Path = "$requestedVersion;$env:Path"
+
+    # also add to the permanent windows path
+    $persistedPaths = @($requestedVersion)
+    [Environment]::GetEnvironmentVariable('Path', 'Machine') -split ';' | % {
+      if (-not($_ -like "$nvmwPath*")) {
+        $persistedPaths += $_
+      }
+    }
+    [Environment]::SetEnvironmentVariable('Path', $persistedPaths -join ';', 'Machine')
+
     $env:NODE_PATH = "$requestedVersion;"
     npm config set prefix $requestedVersion
     $env:NODE_PATH += npm root -g
+
     "Switched to node version $VersionToUse"
 }
 


### PR DESCRIPTION
In addition to setting to the current powershell session path, this change also adds the desired node version to the permanent system path environment variable so that it can be immediately used external to powershell.  The code prevents duplicate entries from occurring in the permanent path.  I found that without this, even though I had used ps-nvmw to install and set my node version, external programs like Sublime Text were unable to access node for plugins like the typescript plugin.
