### PR TITLE
support spaces in MSI file path

### DIFF
--- a/nvm.psm1
+++ b/nvm.psm1
@@ -190,8 +190,9 @@ function Install-NodeVersion {
 
     New-Item $unpackPath -ItemType Directory
 
-    $args = @("/a", (Join-Path $requestedVersion $msiFile), "/qb", "TARGETDIR=`"$unpackPath`"")
-
+    $msiFilePath = (Join-Path $requestedVersion $msiFile)
+    $args = @("/a", "`"$msiFilePath`"", "/qb", "TARGETDIR=`"$unpackPath`"")
+    
     Start-Process -FilePath "msiexec.exe" -Wait -PassThru -ArgumentList $args
 
     Move-Item (Join-Path (Join-Path $unpackPath 'nodejs') '*') -Destination $requestedVersion -Force


### PR DESCRIPTION
Hi

This patch protects spaces in the MSI source path. This is useful when installing from C:\Program Files\WindowsPowerShell\Modules\...

Best regards
Roman