### PR TITLE
feat: support macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Node Version Manager for Windows
+# Node Version Manager for PowerShell
 
-This is a simple PowerShell module for installing and using multiple Node.js versions on Windows. This is inspired by [creationix's nvm](https://github.com/creationix/nvm) tool for bash.
+This is a simple PowerShell module for installing and using multiple Node.js versions in PowerShell. This is inspired by [creationix's nvm](https://github.com/creationix/nvm) tool for bash.
+Works on Windows and on macOS.
 
 # Install via PowerShell Gallery
 

--- a/nvm.psd1
+++ b/nvm.psd1
@@ -27,7 +27,7 @@ CompanyName = 'Aaron Powell'
 Copyright = '(c) 2017 Aaron Powell. All rights reserved.'
 
 # Description of the functionality provided by this module
-Description = 'Node Version Manager - This is a simple PowerShell module for installing and using multiple Node.js versions on Windows.'
+Description = 'Node Version Manager - This is a simple PowerShell module for installing and using multiple Node.js versions in PowerShell.'
 
 # Minimum version of the Windows PowerShell engine required by this module
 PowerShellVersion = '3.0'


### PR DESCRIPTION
Adds support to run on macOS 🎉 

On macOS, will download the `.tar.gz` archive and unpack it the same way we do it for the Windows version. `PATH` is set to the `bin` folder.
Changes needed to make it platform agnostic:
- Use `[System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture` instead of `$env:OS` (which is not available on mac/Unix)
- Uppercase `PATH` env var (Unix/mac are case sensitive, Windows is case insensitive)
- Use `[System.IO.Path]::PathSeparator` instead of `;` as `PATH` separator

Closes #21 