### PR TITLE
Trim down README to Getting Started and generate documentation reference

### DIFF
--- a/.docs/reference.md
+++ b/.docs/reference.md
@@ -1,0 +1,218 @@
+<!-- This file is generated. To regenerate, run .scripts/Generate-Documentation.ps1 -->
+
+# Command Reference
+
+- [`Get-NodeInstallLocation`](#get-nodeinstalllocation)
+- [`Get-NodeVersions`](#get-nodeversions)
+- [`Install-NodeVersion`](#install-nodeversion)
+- [`Remove-NodeVersion`](#remove-nodeversion)
+- [`Set-NodeInstallLocation`](#set-nodeinstalllocation)
+- [`Set-NodeVersion`](#set-nodeversion)
+
+### `Get-NodeInstallLocation`
+<a id="get-nodeinstalllocation"></a>
+
+Will return the path that node.js versions will be installed into
+
+```powershell
+Get-NodeInstallLocation 
+```
+
+#### Parameters
+None
+
+
+#### Examples
+
+```powershell
+
+```
+
+
+### `Get-NodeVersions`
+<a id="get-nodeversions"></a>
+
+Used to show all the node.js versions installed to nvm, using the -Remote option allows you to list versions of node.js available for install. Providing a -Filter parameter can filter the versions using the pattern, either local or remote versions. The versions are sorted from highest to lowest and can be compared with PowerShell operators.
+
+```powershell
+Get-NodeVersions -Remote <SwitchParameter> -Filter <String>
+```
+
+#### Parameters
+- `-Remote <SwitchParameter>`  
+  Indicate whether or not to list local or remote versions
+ - `-Filter <String>`  
+  A semver version range to filter versions
+
+
+
+#### Examples
+
+```powershell
+Get-NodeVersions -Remote -Filter ">=7.0.0 <9.0.0"
+```
+
+Show all versions available to download between v7 and v9    
+ 
+```powershell
+Get-NodeVersions -Filter '>=7.0.0 <9.0.0' | % {"$_"}
+```
+
+Return the installed versions as strings    
+ 
+```powershell
+(Get-NodeVersions | Select-Object -First 1) -lt (Get-NodeVersions -Remote | Select-Object -First 1)
+```
+
+    
+### `Install-NodeVersion`
+<a id="install-nodeversion"></a>
+
+Download and install the specified version of node.js into the nvm directory. Once installed it can be used with Set-NodeVersion
+
+```powershell
+Install-NodeVersion -Version <String> -Force <SwitchParameter> -Architecture <String> -Proxy <String>
+```
+
+#### Parameters
+- `-Version <String>`  
+  A semver range for the version of node.js to install
+ - `-Force <SwitchParameter>`  
+  Reinstall an already installed version of node.js
+ - `-Architecture <String>`  
+  The architecture of node.js to install, defaults to [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+ - `-Proxy <String>`  
+  Define HTTP proxy used when downloading an installer
+
+
+
+#### Examples
+
+```powershell
+Install-NodeVersion v5.0.0
+```
+
+Install version 5.0.0 of node.js into the module directory    
+ 
+```powershell
+Install-NodeVersion ^5
+```
+
+Install the latest 5.x.x version of node.js into the module directory    
+ 
+```powershell
+Install-NodeVersion v5.0.0 -Architecture x86
+```
+
+Installs the x86 version even if you're on an x64 machine    
+ 
+```powershell
+Install-NodeVersion v5.0.0 -Architecture x86 -proxy http://localhost:3128
+```
+
+Installs the x86 version even if you're on an x64 machine using default CNTLM proxy    
+### `Remove-NodeVersion`
+<a id="remove-nodeversion"></a>
+
+Removes an installed version of node.js along with any installed npm modules
+
+```powershell
+Remove-NodeVersion -Version <String>
+```
+
+#### Parameters
+- `-Version <String>`  
+  The full version string of the node.js package to remove
+
+
+
+#### Examples
+
+```powershell
+Remove-NodeVersion v5.0.0
+```
+
+Removes the v5.0.0 version of node.js from the nvm store    
+### `Set-NodeInstallLocation`
+<a id="set-nodeinstalllocation"></a>
+
+This is used to override the default node.js install path for nvm, which is relative to the module install location. You would want to use this to get around the Windows path limit problem that plagues node.js installed. Note that to avoid collisions the unpacked files will be in a folder `.nvm\<version>` in the specified location.
+
+```powershell
+Set-NodeInstallLocation -Path <String>
+```
+
+#### Parameters
+- `-Path <String>`  
+  The root folder for nvm
+
+
+
+#### Examples
+
+```powershell
+Set-NodeInstallLocation -Path C:\Temp
+```
+
+    
+### `Set-NodeVersion`
+<a id="set-nodeversion"></a>
+
+Set's the node.js version that was either provided with the -Version parameter, from using the .nvmrc file or the node engines field in package.json in the current working directory.
+
+```powershell
+Set-NodeVersion -Version <String> -Persist <String>
+```
+
+#### Parameters
+- `-Version <String>`  
+  A semver version range for the node.js version you wish to use.
+ - `-Persist <String>`  
+  If present, this will also set the node.js version to the permanent system path, of the specified scope, which will persist this setting for future powershell sessions and causes this version of node.js to be referenced outside of powershell.
+
+
+
+#### Examples
+
+```powershell
+Set-NodeVersion
+```
+
+Set based on the .nvmrc or package.json engines node field    
+ 
+```powershell
+Set-NodeVersion 5.0.1
+```
+
+Set using explicit version    
+ 
+```powershell
+Set-NodeVersion ~5.2
+```
+
+Sets to the latest installed patch version of v5.2    
+ 
+```powershell
+Set-NodeVersion ^5
+```
+
+Sets to the latest installed v5 version    
+ 
+```powershell
+Set-NodeVersion '>=5.0.0 <7.0.0'
+```
+
+Sets to the latest installed version between v5 and v7    
+ 
+```powershell
+Set-NodeVersion v5.0.1 -Persist User
+```
+
+Set and persist in permamant system path for the current user    
+ 
+```powershell
+Set-NodeVersion v5.0.1 -Persist Machine
+```
+
+Set and persist in permamant system path for the machine (Note: requires an admin shell)    
+

--- a/.scripts/Generate-Documentation.ps1
+++ b/.scripts/Generate-Documentation.ps1
@@ -58,16 +58,12 @@ $examples
 }
 
 $fullMd = @"
-<!-- BEGIN OF GENERATED DOCUMENTATION -->
-<!-- to regenerate, run .scripts/Generate-Documentation.ps1 -->
-## Command Reference
+<!-- This file is generated. To regenerate, run .scripts/Generate-Documentation.ps1 -->
+
+# Command Reference
 
 $toc
 $doc
-<!-- END OF GENERATED DOCUMENTATION -->
 "@
 
-# Escape regexp special characters ($)
-$replacement = $fullMd -replace '\$', '$$$$'
-
-((Get-Content -Raw "$PSScriptRoot/../README.md") -replace '(?ms)<!-- BEGIN OF GENERATED DOCUMENTATION -->.*<!-- END OF GENERATED DOCUMENTATION -->', $replacement).TrimEnd() | Out-File "$PSScriptRoot/../README.md"
+$fullMd | Out-File "$PSScriptRoot/../.docs/reference.md"

--- a/.scripts/Generate-Documentation.ps1
+++ b/.scripts/Generate-Documentation.ps1
@@ -1,4 +1,6 @@
 
+Import-Module "$PSScriptRoot/../nvm.psd1"
+
 $toc = ''
 $doc = ''
 

--- a/.scripts/Generate-Documentation.ps1
+++ b/.scripts/Generate-Documentation.ps1
@@ -1,0 +1,73 @@
+
+$toc = ''
+$doc = ''
+
+(Get-Module nvm).ExportedCommands.Values.Name | Sort-Object | ForEach-Object {
+    $help = Get-Help $_
+
+    $toc += @"
+- [``$($help.Name)``](#$($help.Name.ToLower()))
+
+"@
+
+    $examples = $help.examples.example | ForEach-Object {
+        @"
+
+``````powershell
+$($_.code)
+``````
+
+$($_.remarks.Text)
+
+"@
+    }
+
+    $parameters = if ($help.parameters.parameter -eq $null) {
+        'None'
+    }
+    else {
+        $help.parameters.parameter | ForEach-Object {
+            @"
+- ``-$($_.name) <$($_.type.name)>``$('  ')
+  $($_.description.Text)
+
+"@
+        }
+    }
+
+    $inlineParameters = ($help.parameters.parameter | Where-Object { $_ -ne $null } | ForEach-Object { "-$($_.name) <$($_.type.name)>" }) -join ' '
+
+    $commandDoc = @"
+### ``$($help.Name)``
+<a id="$($help.Name.ToLower())"></a>
+
+$($help.description.Text)
+
+``````powershell
+$($help.Name) $inlineParameters
+``````
+
+#### Parameters
+$parameters
+
+
+#### Examples
+$examples
+"@
+    $doc += $commandDoc
+}
+
+$fullMd = @"
+<!-- BEGIN OF GENERATED DOCUMENTATION -->
+<!-- to regenerate, run .scripts/Generate-Documentation.ps1 -->
+## Command Reference
+
+$toc
+$doc
+<!-- END OF GENERATED DOCUMENTATION -->
+"@
+
+# Escape regexp special characters ($)
+$replacement = $fullMd -replace '\$', '$$$$'
+
+((Get-Content -Raw "$PSScriptRoot/../README.md") -replace '(?ms)<!-- BEGIN OF GENERATED DOCUMENTATION -->.*<!-- END OF GENERATED DOCUMENTATION -->', $replacement).TrimEnd() | Out-File "$PSScriptRoot/../README.md"

--- a/.scripts/ps-nvm.csproj
+++ b/.scripts/ps-nvm.csproj
@@ -11,9 +11,9 @@
   </ItemGroup>
 
   <Target Name="CleanUp" AfterTargets="Publish">
-    <Delete Files="../ps-nvmw.pdb" />
-    <Delete Files="../ps-nvmw.deps.json" />
-    <Delete Files="../ps-nvmw.dll" />
+    <Delete Files="../ps-nvm.pdb" />
+    <Delete Files="../ps-nvm.deps.json" />
+    <Delete Files="../ps-nvm.dll" />
   </Target>
 
 </Project>

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ install:
   - cd .scripts && dotnet publish -o .. && cd ..
 
 script:
+  # Check that documentation was regenerated if needed
+  - pwsh .scripts/Generate-Documentation.ps1
+  - git diff --exit-code .docs/reference.md
   # Run tests and generate coverage report
   - pwsh -c '& {
       Import-Module ./.scripts/CodeCovIo.psm1;

--- a/README.md
+++ b/README.md
@@ -50,10 +50,15 @@ If you don't specify a version and no .nvmrc is found, ps-nvm will read a packag
 ## Contributing
 
 ```powershell
+# Install dependencies
+cd .scripts
+dotnet publish -o ..
+cd ..
+
 # Run tests
 Install-Module Pester
 Invoke-Pester
 
-# Regenerate reference documentation
+# Regenerate documentation
 ./.scripts/GenerateDocumentation.ps1
 ```

--- a/README.md
+++ b/README.md
@@ -3,74 +3,261 @@
 [![powershellgallery](https://img.shields.io/powershellgallery/v/nvm.svg)](https://www.powershellgallery.com/packages/nvm)
 [![downloads](https://img.shields.io/powershellgallery/dt/nvm.svg?label=downloads)](https://www.powershellgallery.com/packages/nvm)
 [![codecov](https://codecov.io/gh/aaronpowell/ps-nvm/branch/master/graph/badge.svg)](https://codecov.io/gh/aaronpowell/ps-nvm)
-
-| Operating System | Build Status |
-| ---------------- | ------------ |
-| Windows | [![Build status (Windows)](https://ci.appveyor.com/api/projects/status/iuytgb4lg1wp458f/branch/master?svg=true)](https://ci.appveyor.com/project/aaronpowell/ps-nvm/branch/master) |
-| OSX, Linux | [![Build Status (OSX, Linux)](https://travis-ci.org/aaronpowell/ps-nvm.svg?branch=master)](https://travis-ci.org/aaronpowell/ps-nvm) |
+[![windows build](https://img.shields.io/appveyor/ci/aaronpowell/ps-nvm/master.svg?label=windows+build)](https://ci.appveyor.com/project/aaronpowell/ps-nvm)
+[![macos/linux build](https://img.shields.io/travis/aaronpowell/ps-nvm/master.svg?label=macos/linux+build)](https://travis-ci.org/aaronpowell/ps-nvm)
 
 This is a simple PowerShell module for installing and using multiple Node.js versions in PowerShell. This is inspired by [creationix's nvm](https://github.com/creationix/nvm) tool for bash.
 
 Works on Windows, macOS and Linux.
 
-# Install via PowerShell Gallery
+## Install via PowerShell Gallery
 
 nvm is available on the [PowerShell Gallery](https://www.powershellgallery.com/) as [nvm](https://www.powershellgallery.com/packages/nvm) and can easily be installed with:
 
-```
-PS> Install-Module -Name nvm
+```ps
+Install-Module -Name nvm
 ```
 
 You can then import the module or add it to your profile for auto-importing.
 
-# Installing manually
+## Installing manually
 
 Clone this repository or put the `psm1` somewhere on disk and import the module:
 
-    Import-Module <path to nvm.psm1>
+```ps
+Import-Module path/to/nvm.psm1
+```
 
-# Commands
+## Semver ranges
 
-There are 6 PowerShell commands exposed. You're best using `Get-Help <command>` for proper help, but here's a quick overview.
+ps-nvm works with [semver ranges as used by npm](https://docs.npmjs.com/misc/semver#ranges).
+For example, you can pass `^6.0.0` or just `6` to `Install-NodeVersion` to install the latest 6.x.x version, or even `>=6.0.0 <9.0.0` to install the latest version between v6 and v7.
+Versions returned are [`SemVer.Version` objects](https://github.com/adamreeve/semver.net#readme) that can be compared with comparison operators like `-gt` and `-lt`.
 
-_Note: Node.js will restrict you to a version number of v#.#.#_
+## .nvmrc
 
-## `Install-NodeVersion <version>`
+If you don't specify a version for commands, ps-nvm will look for an .nvmrc plain text file in the current directory containing a node version to install.
 
-    Install-NodeVersion v0.10.33
+## package.json `engines.node`
 
-This will install the specified Node.js. You can also use a `-Force` flag to override an existing install. If you do not specify a version, the module searches for a .nvmrc file and reads the version from this file if available.
+If you don't specify a version and no .nvmrc is found, ps-nvm will read a package.json file in the current directory and use whatever version satisfies the [`engines.node` field](https://docs.npmjs.com/files/package.json#engines).
+
+<!-- BEGIN OF GENERATED DOCUMENTATION -->
+<!-- to regenerate, run .scripts/Generate-Documentation.ps1 -->
+## Command Reference
+
+- [`Get-NodeInstallLocation`](#get-nodeinstalllocation)
+- [`Get-NodeVersions`](#get-nodeversions)
+- [`Install-NodeVersion`](#install-nodeversion)
+- [`Remove-NodeVersion`](#remove-nodeversion)
+- [`Set-NodeInstallLocation`](#set-nodeinstalllocation)
+- [`Set-NodeVersion`](#set-nodeversion)
+
+### `Get-NodeInstallLocation`
+<a id="get-nodeinstalllocation"></a>
+
+Will return the path that node.js versions will be installed into
+
+```powershell
+Get-NodeInstallLocation 
+```
+
+#### Parameters
+None
 
 
-## `Remove-NodeVersion <version>`
+#### Examples
 
-    Remove-NodeVersion v0.10.33
+```powershell
+Get-NodeInstallLocation
+```
 
-This will remove the specified Node.js version from your machine.
+    
+### `Get-NodeVersions`
+<a id="get-nodeversions"></a>
 
-## `Get-NodeVersions`
+Used to show all the node.js versions installed to nvm, using the -Remote option allows you to list versions of node.js available for install. Providing a -Filter parameter can filter the versions using the pattern, either local or remote versions. The versions are sorted from highest to lowest and can be compared with PowerShell operators.
 
-    Get-NodeVersions
+```powershell
+Get-NodeVersions -Remote <SwitchParameter> -Filter <String>
+```
 
-Shows a list of what Node.js versions are available.
+#### Parameters
+- `-Remote <SwitchParameter>`  
+  Indicate whether or not to list local or remote versions
+ - `-Filter <String>`  
+  A semver version range to filter versions
 
-## `Set-NodeVersion <version>`
 
-    Set-NodeVersion v0.10.33
 
-Makes the specified Node.js version the currently loaded Node.js version for your terminal.
+#### Examples
 
-If you omit the `version` argument it will search for a `.nvmrc` file in the current directory and use that as the version.
+```powershell
+Get-NodeVersions -Remote -Filter ">=7.0.0 <9.0.0"
+```
 
-## `Get-NodeInstallLocation`
+Show all versions available to download between v7 and v9    
+ 
+```powershell
+Get-NodeVersions -Filter '>=7.0.0 <9.0.0' | % {"$_"}
+```
 
-    Get-NodeInstallLocation
+Return the installed versions as strings    
+ 
+```powershell
+(Get-NodeVersions | Select-Object -First 1) -lt (Get-NodeVersions -Remote | Select-Object -First 1)
+```
 
-Returns the path where Node.js will be looking for and installing new versions into.
+    
+### `Install-NodeVersion`
+<a id="install-nodeversion"></a>
 
-## `Set-NodeInstallLocation`
+Download and install the specified version of node.js into the nvm directory. Once installed it can be used with Set-NodeVersion
 
-    Set-NodeInstallLocation -Path C:\temp
+```powershell
+Install-NodeVersion -Version <String> -Force <SwitchParameter> -Architecture <String> -Proxy <String>
+```
 
-Sets the base folder which Node.js versions will be installed into.
+#### Parameters
+- `-Version <String>`  
+  A semver range for the version of node.js to install
+ - `-Force <SwitchParameter>`  
+  Reinstall an already installed version of node.js
+ - `-Architecture <String>`  
+  The architecture of node.js to install, defaults to [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+ - `-Proxy <String>`  
+  Define HTTP proxy used when downloading an installer
 
+
+
+#### Examples
+
+```powershell
+Install-NodeVersion v5.0.0
+```
+
+Install version 5.0.0 of node.js into the module directory    
+ 
+```powershell
+Install-NodeVersion ^5
+```
+
+Install the latest 5.x.x version of node.js into the module directory    
+ 
+```powershell
+Install-NodeVersion v5.0.0 -Architecture x86
+```
+
+Installs the x86 version even if you're on an x64 machine    
+ 
+```powershell
+Install-NodeVersion v5.0.0 -Architecture x86 -proxy http://localhost:3128
+```
+
+Installs the x86 version even if you're on an x64 machine using default CNTLM proxy    
+### `Remove-NodeVersion`
+<a id="remove-nodeversion"></a>
+
+Removes an installed version of node.js along with any installed npm modules
+
+```powershell
+Remove-NodeVersion -Version <String>
+```
+
+#### Parameters
+- `-Version <String>`  
+  The full version string of the node.js package to remove
+
+
+
+#### Examples
+
+```powershell
+Remove-NodeVersion v5.0.0
+```
+
+Removes the v5.0.0 version of node.js from the nvm store    
+### `Set-NodeInstallLocation`
+<a id="set-nodeinstalllocation"></a>
+
+This is used to override the default node.js install path for nvm, which is relative to the module install location. You would want to use this to get around the Windows path limit problem that plagues node.js installed. Note that to avoid collisions the unpacked files will be in a folder `.nvm\<version>` in the specified location.
+
+```powershell
+Set-NodeInstallLocation -Path <String>
+```
+
+#### Parameters
+- `-Path <String>`  
+  The root folder for nvm
+
+
+
+#### Examples
+
+```powershell
+Set-NodeInstallLocation -Path C:\Temp
+```
+
+    
+### `Set-NodeVersion`
+<a id="set-nodeversion"></a>
+
+Set's the node.js version that was either provided with the -Version parameter, from using the .nvmrc file or the node engines field in package.json in the current working directory.
+
+```powershell
+Set-NodeVersion -Version <String> -Persist <String>
+```
+
+#### Parameters
+- `-Version <String>`  
+  A semver version range for the node.js version you wish to use.
+ - `-Persist <String>`  
+  If present, this will also set the node.js version to the permanent system path, of the specified scope, which will persist this setting for future powershell sessions and causes this version of node.js to be referenced outside of powershell.
+
+
+
+#### Examples
+
+```powershell
+Set-NodeVersion
+```
+
+Set based on the .nvmrc or package.json engines node field    
+ 
+```powershell
+Set-NodeVersion 5.0.1
+```
+
+Set using explicit version    
+ 
+```powershell
+Set-NodeVersion ~5.2
+```
+
+Sets to the latest installed patch version of v5.2    
+ 
+```powershell
+Set-NodeVersion ^5
+```
+
+Sets to the latest installed v5 version    
+ 
+```powershell
+Set-NodeVersion '>=5.0.0 <7.0.0'
+```
+
+Sets to the latest installed version between v5 and v7    
+ 
+```powershell
+Set-NodeVersion v5.0.1 -Persist User
+```
+
+Set and persist in permamant system path for the current user    
+ 
+```powershell
+Set-NodeVersion v5.0.1 -Persist Machine
+```
+
+Set and persist in permamant system path for the machine (Note: requires an admin shell)    
+
+<!-- END OF GENERATED DOCUMENTATION -->

--- a/README.md
+++ b/README.md
@@ -10,254 +10,39 @@ This is a simple PowerShell module for installing and using multiple Node.js ver
 
 Works on Windows, macOS and Linux.
 
-## Install via PowerShell Gallery
+## Getting Started
 
-nvm is available on the [PowerShell Gallery](https://www.powershellgallery.com/) as [nvm](https://www.powershellgallery.com/packages/nvm) and can easily be installed with:
+```powershell
+# Install from the PowerShell Gallery
+Install-Module nvm
 
-```ps
-Install-Module -Name nvm
+# Install Node v7
+Install-NodeVersion 7
+
+# Set active Node version in PATH to v7
+Set-NodeVersion 7
+
+# Set default Node version for the current user to v7 (Windows only)
+Set-NodeVersion -Persist User 7
+
+# Install the Node version specified in .nvmrc or package.json engine field
+Install-NodeVersion
 ```
 
-You can then import the module or add it to your profile for auto-importing.
+📖 [Full Command Reference](./.docs/reference.md)
 
-## Installing manually
+## Features
 
-Clone this repository or put the `psm1` somewhere on disk and import the module:
-
-```ps
-Import-Module path/to/nvm.psm1
-```
-
-## Semver ranges
+### Semver ranges
 
 ps-nvm works with [semver ranges as used by npm](https://docs.npmjs.com/misc/semver#ranges).
 For example, you can pass `^6.0.0` or just `6` to `Install-NodeVersion` to install the latest 6.x.x version, or even `>=6.0.0 <9.0.0` to install the latest version between v6 and v7.
 Versions returned are [`SemVer.Version` objects](https://github.com/adamreeve/semver.net#readme) that can be compared with comparison operators like `-gt` and `-lt`.
 
-## .nvmrc
+### .nvmrc
 
 If you don't specify a version for commands, ps-nvm will look for an .nvmrc plain text file in the current directory containing a node version to install.
 
-## package.json `engines.node`
+### package.json `engines.node`
 
 If you don't specify a version and no .nvmrc is found, ps-nvm will read a package.json file in the current directory and use whatever version satisfies the [`engines.node` field](https://docs.npmjs.com/files/package.json#engines).
-
-<!-- BEGIN OF GENERATED DOCUMENTATION -->
-<!-- to regenerate, run .scripts/Generate-Documentation.ps1 -->
-## Command Reference
-
-- [`Get-NodeInstallLocation`](#get-nodeinstalllocation)
-- [`Get-NodeVersions`](#get-nodeversions)
-- [`Install-NodeVersion`](#install-nodeversion)
-- [`Remove-NodeVersion`](#remove-nodeversion)
-- [`Set-NodeInstallLocation`](#set-nodeinstalllocation)
-- [`Set-NodeVersion`](#set-nodeversion)
-
-### `Get-NodeInstallLocation`
-<a id="get-nodeinstalllocation"></a>
-
-Will return the path that node.js versions will be installed into
-
-```powershell
-Get-NodeInstallLocation 
-```
-
-#### Parameters
-None
-
-
-#### Examples
-
-```powershell
-Get-NodeInstallLocation
-```
-
-    
-### `Get-NodeVersions`
-<a id="get-nodeversions"></a>
-
-Used to show all the node.js versions installed to nvm, using the -Remote option allows you to list versions of node.js available for install. Providing a -Filter parameter can filter the versions using the pattern, either local or remote versions. The versions are sorted from highest to lowest and can be compared with PowerShell operators.
-
-```powershell
-Get-NodeVersions -Remote <SwitchParameter> -Filter <String>
-```
-
-#### Parameters
-- `-Remote <SwitchParameter>`  
-  Indicate whether or not to list local or remote versions
- - `-Filter <String>`  
-  A semver version range to filter versions
-
-
-
-#### Examples
-
-```powershell
-Get-NodeVersions -Remote -Filter ">=7.0.0 <9.0.0"
-```
-
-Show all versions available to download between v7 and v9    
- 
-```powershell
-Get-NodeVersions -Filter '>=7.0.0 <9.0.0' | % {"$_"}
-```
-
-Return the installed versions as strings    
- 
-```powershell
-(Get-NodeVersions | Select-Object -First 1) -lt (Get-NodeVersions -Remote | Select-Object -First 1)
-```
-
-    
-### `Install-NodeVersion`
-<a id="install-nodeversion"></a>
-
-Download and install the specified version of node.js into the nvm directory. Once installed it can be used with Set-NodeVersion
-
-```powershell
-Install-NodeVersion -Version <String> -Force <SwitchParameter> -Architecture <String> -Proxy <String>
-```
-
-#### Parameters
-- `-Version <String>`  
-  A semver range for the version of node.js to install
- - `-Force <SwitchParameter>`  
-  Reinstall an already installed version of node.js
- - `-Architecture <String>`  
-  The architecture of node.js to install, defaults to [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
- - `-Proxy <String>`  
-  Define HTTP proxy used when downloading an installer
-
-
-
-#### Examples
-
-```powershell
-Install-NodeVersion v5.0.0
-```
-
-Install version 5.0.0 of node.js into the module directory    
- 
-```powershell
-Install-NodeVersion ^5
-```
-
-Install the latest 5.x.x version of node.js into the module directory    
- 
-```powershell
-Install-NodeVersion v5.0.0 -Architecture x86
-```
-
-Installs the x86 version even if you're on an x64 machine    
- 
-```powershell
-Install-NodeVersion v5.0.0 -Architecture x86 -proxy http://localhost:3128
-```
-
-Installs the x86 version even if you're on an x64 machine using default CNTLM proxy    
-### `Remove-NodeVersion`
-<a id="remove-nodeversion"></a>
-
-Removes an installed version of node.js along with any installed npm modules
-
-```powershell
-Remove-NodeVersion -Version <String>
-```
-
-#### Parameters
-- `-Version <String>`  
-  The full version string of the node.js package to remove
-
-
-
-#### Examples
-
-```powershell
-Remove-NodeVersion v5.0.0
-```
-
-Removes the v5.0.0 version of node.js from the nvm store    
-### `Set-NodeInstallLocation`
-<a id="set-nodeinstalllocation"></a>
-
-This is used to override the default node.js install path for nvm, which is relative to the module install location. You would want to use this to get around the Windows path limit problem that plagues node.js installed. Note that to avoid collisions the unpacked files will be in a folder `.nvm\<version>` in the specified location.
-
-```powershell
-Set-NodeInstallLocation -Path <String>
-```
-
-#### Parameters
-- `-Path <String>`  
-  The root folder for nvm
-
-
-
-#### Examples
-
-```powershell
-Set-NodeInstallLocation -Path C:\Temp
-```
-
-    
-### `Set-NodeVersion`
-<a id="set-nodeversion"></a>
-
-Set's the node.js version that was either provided with the -Version parameter, from using the .nvmrc file or the node engines field in package.json in the current working directory.
-
-```powershell
-Set-NodeVersion -Version <String> -Persist <String>
-```
-
-#### Parameters
-- `-Version <String>`  
-  A semver version range for the node.js version you wish to use.
- - `-Persist <String>`  
-  If present, this will also set the node.js version to the permanent system path, of the specified scope, which will persist this setting for future powershell sessions and causes this version of node.js to be referenced outside of powershell.
-
-
-
-#### Examples
-
-```powershell
-Set-NodeVersion
-```
-
-Set based on the .nvmrc or package.json engines node field    
- 
-```powershell
-Set-NodeVersion 5.0.1
-```
-
-Set using explicit version    
- 
-```powershell
-Set-NodeVersion ~5.2
-```
-
-Sets to the latest installed patch version of v5.2    
- 
-```powershell
-Set-NodeVersion ^5
-```
-
-Sets to the latest installed v5 version    
- 
-```powershell
-Set-NodeVersion '>=5.0.0 <7.0.0'
-```
-
-Sets to the latest installed version between v5 and v7    
- 
-```powershell
-Set-NodeVersion v5.0.1 -Persist User
-```
-
-Set and persist in permamant system path for the current user    
- 
-```powershell
-Set-NodeVersion v5.0.1 -Persist Machine
-```
-
-Set and persist in permamant system path for the machine (Note: requires an admin shell)    
-
-<!-- END OF GENERATED DOCUMENTATION -->

--- a/README.md
+++ b/README.md
@@ -46,3 +46,14 @@ If you don't specify a version for commands, ps-nvm will look for an .nvmrc plai
 ### package.json `engines.node`
 
 If you don't specify a version and no .nvmrc is found, ps-nvm will read a package.json file in the current directory and use whatever version satisfies the [`engines.node` field](https://docs.npmjs.com/files/package.json#engines).
+
+## Contributing
+
+```powershell
+# Run tests
+Install-Module Pester
+Invoke-Pester
+
+# Regenerate reference documentation
+./.scripts/GenerateDocumentation.ps1
+```

--- a/nvm.psm1
+++ b/nvm.psm1
@@ -25,34 +25,36 @@ function IsWindows() {
 function Set-NodeVersion {
     <#
     .Synopsis
-       Set the node.js version for the current session
+        Set the node.js version for the current session
     .Description
-       Set's the node.js version that was either provided with the -Version parameter, from using the .nvmrc file or the node engines field in package.json in the current working directory.
-    .Parameter $Version
-       A semver version range for the node.js version you wish to use.
-    .Parameter $Persist
-       If present, this will also set the node.js version to the permanent system path, of the specified scope, which will persist this setting for future powershell sessions and causes this version of node.js to be referenced outside of powershell.
+        Set's the node.js version that was either provided with the -Version parameter, from using the .nvmrc file or the node engines field in package.json in the current working directory.
+    .Parameter Version
+        A semver version range for the node.js version you wish to use.
+    .Parameter Persist
+        If present, this will also set the node.js version to the permanent system path, of the specified scope, which will persist this setting for future powershell sessions and causes this version of node.js to be referenced outside of powershell.
     .Example
-       Set based on the .nvmrc or package.json engines node field
-       Set-NodeVersion
+        C:\PS> Set-NodeVersion
+        Set based on the .nvmrc or package.json engines node field
     .Example
-       Set-NodeVersion 5.0.1
-       Set using explicit version
+        C:\PS> Set-NodeVersion 5.0.1
+        Set using explicit version
     .Example
-       Set-NodeVersion ~5.2
-       Sets to the latest installed patch version of v5.2
+        C:\PS> Set-NodeVersion ~5.2
+        Sets to the latest installed patch version of v5.2
     .Example
-       Set-NodeVersion ^5
-       Sets to the latest installed v5 version
+        C:\PS> Set-NodeVersion ^5
+        Sets to the latest installed v5 version
     .Example
-       Set-NodeVersion '>=5.0.0 <7.0.0'
-       Sets to the latest installed version between v5 and v7
+        C:\PS> Set-NodeVersion '>=5.0.0 <7.0.0'
+        Sets to the latest installed version between v5 and v7
     .Example
-       Set-NodeVersion v5.0.1 -Persist User
-       Set and persist in permamant system path for the current user
+        C:\PS> Set-NodeVersion v5.0.1 -Persist User
+        Set and persist in permamant system path for the current user
     .Example
-       Set-NodeVersion v5.0.1 -Persist Machine
-       Set and persist in permamant system path for the machine (Note: requires an admin shell)
+        C:\PS> Set-NodeVersion v5.0.1 -Persist Machine
+        Set and persist in permamant system path for the machine (Note: requires an admin shell)
+    .Link
+        https://github.com/aaronpowell/ps-nvm#set-nodeversion
     #>
     param(
         [string]
@@ -137,26 +139,28 @@ function Install-NodeVersion {
         Install a version of node.js
     .Description
         Download and install the specified version of node.js into the nvm directory. Once installed it can be used with Set-NodeVersion
-    .Parameter $Version
+    .Parameter Version
         A semver range for the version of node.js to install
-    .Parameter $Force
+    .Parameter Force
         Reinstall an already installed version of node.js
-    .Parameter $architecture
+    .Parameter Architecture
         The architecture of node.js to install, defaults to [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
-    .Parameter $proxy
+    .Parameter Proxy
         Define HTTP proxy used when downloading an installer
     .Example
-        Install-NodeVersion v5.0.0
+        C:\PS> Install-NodeVersion v5.0.0
         Install version 5.0.0 of node.js into the module directory
     .Example
-        Install-NodeVersion ^5
+        C:\PS> Install-NodeVersion ^5
         Install the latest 5.x.x version of node.js into the module directory
     .Example
-        Install-NodeVersion v5.0.0 -Architecture x86
+        C:\PS> Install-NodeVersion v5.0.0 -Architecture x86
         Installs the x86 version even if you're on an x64 machine
     .Example
-        Install-NodeVersion v5.0.0 -Architecture x86 -proxy http://localhost:3128
+        C:\PS> Install-NodeVersion v5.0.0 -Architecture x86 -proxy http://localhost:3128
         Installs the x86 version even if you're on an x64 machine using default CNTLM proxy
+    .Link
+        https://github.com/aaronpowell/ps-nvm#install-nodeversion
     #>
     param(
         [string]
@@ -280,11 +284,13 @@ function Remove-NodeVersion {
         Removes an installed version of node.js
     .Description
         Removes an installed version of node.js along with any installed npm modules
-    .Parameter $Version
+    .Parameter Version
         The full version string of the node.js package to remove
     .Example
-        Remove-NodeVersion v5.0.0
+        C:\PS> Remove-NodeVersion v5.0.0
         Removes the v5.0.0 version of node.js from the nvm store
+    .Link
+        https://github.com/aaronpowell/ps-nvm#get-nodeversion
     #>
     param(
         [string]
@@ -311,33 +317,20 @@ function Get-NodeVersions {
         List local or remote node.js versions
     .Description
         Used to show all the node.js versions installed to nvm, using the -Remote option allows you to list versions of node.js available for install. Providing a -Filter parameter can filter the versions using the pattern, either local or remote versions. The versions are sorted from highest to lowest and can be compared with PowerShell operators.
-    .Parameter $Remote
+    .Parameter Remote
         Indicate whether or not to list local or remote versions
-    .Parameter $Filter
+    .Parameter Filter
         A semver version range to filter versions
     .Example
-        Get-NodeVersions -Filter '>=7.0.0 <9.0.0'
-
-        Major      : 8
-        Minor      : 9
-        Patch      : 1
-        PreRelease :
-        Build      :
-
-        Major      : 7
-        Minor      : 9
-        Patch      : 0
-        PreRelease :
-        Build      :
+        C:\PS> Get-NodeVersions -Remote -Filter ">=7.0.0 <9.0.0"
+        Show all versions available to download between v7 and v9
     .Example
-        Get-NodeVersions -Filter '>=7.0.0 <9.0.0' | % {"$_"}
-
-        v8.9.1
-        v7.9.0
+        C:\PS> Get-NodeVersions -Filter '>=7.0.0 <9.0.0' | % {"$_"}
+        Return the installed versions as strings
     .Example
-        (Get-NodeVersions | Select-Object -First 1) -lt (Get-NodeVersions -Remote | Select-Object -First 1)
-
-        True
+        C:\PS>(Get-NodeVersions | Select-Object -First 1) -lt (Get-NodeVersions -Remote | Select-Object -First 1)
+    .Link
+        https://github.com/aaronpowell/ps-nvm#get-nodeversion
     #>
     param(
         [switch]
@@ -372,10 +365,10 @@ function Set-NodeInstallLocation {
         Sets the path where node.js versions will be installed into
     .Description
         This is used to override the default node.js install path for nvm, which is relative to the module install location. You would want to use this to get around the Windows path limit problem that plagues node.js installed. Note that to avoid collisions the unpacked files will be in a folder `.nvm\<version>` in the specified location.
-    .Parameter $Path
+    .Parameter Path
         The root folder for nvm
     .Example
-        Set-NodeInstallLocation -Path C:\Temp
+        C:\PS> Set-NodeInstallLocation -Path C:\Temp
     #>
     param(
         [string]
@@ -404,9 +397,8 @@ function Get-NodeInstallLocation {
         Gets the currnet node.js install path
     .Description
         Will return the path that node.js versions will be installed into
-    .Example
-        Get-NodeInstallLocation
-        c:\tmp\.nvm
+    .Link
+        https://github.com/aaronpowell/ps-nvm#get-nodeinstalllocation
     #>
     $settings = $null
     $settingsFile = Join-Path $PSScriptRoot 'settings.json'

--- a/nvm.psm1
+++ b/nvm.psm1
@@ -54,7 +54,7 @@ function Set-NodeVersion {
         C:\PS> Set-NodeVersion v5.0.1 -Persist Machine
         Set and persist in permamant system path for the machine (Note: requires an admin shell)
     .Link
-        https://github.com/aaronpowell/ps-nvm#set-nodeversion
+        https://github.com/aaronpowell/ps-nvm/blob/master/.docs/reference.md/blob/master/.docs/reference.md#set-nodeversion
     #>
     param(
         [string]
@@ -160,7 +160,7 @@ function Install-NodeVersion {
         C:\PS> Install-NodeVersion v5.0.0 -Architecture x86 -proxy http://localhost:3128
         Installs the x86 version even if you're on an x64 machine using default CNTLM proxy
     .Link
-        https://github.com/aaronpowell/ps-nvm#install-nodeversion
+        https://github.com/aaronpowell/ps-nvm/blob/master/.docs/reference.md#install-nodeversion
     #>
     param(
         [string]
@@ -290,7 +290,7 @@ function Remove-NodeVersion {
         C:\PS> Remove-NodeVersion v5.0.0
         Removes the v5.0.0 version of node.js from the nvm store
     .Link
-        https://github.com/aaronpowell/ps-nvm#get-nodeversion
+        https://github.com/aaronpowell/ps-nvm/blob/master/.docs/reference.md#get-nodeversion
     #>
     param(
         [string]
@@ -330,7 +330,7 @@ function Get-NodeVersions {
     .Example
         C:\PS>(Get-NodeVersions | Select-Object -First 1) -lt (Get-NodeVersions -Remote | Select-Object -First 1)
     .Link
-        https://github.com/aaronpowell/ps-nvm#get-nodeversion
+        https://github.com/aaronpowell/ps-nvm/blob/master/.docs/reference.md#get-nodeversion
     #>
     param(
         [switch]
@@ -398,7 +398,7 @@ function Get-NodeInstallLocation {
     .Description
         Will return the path that node.js versions will be installed into
     .Link
-        https://github.com/aaronpowell/ps-nvm#get-nodeinstalllocation
+        https://github.com/aaronpowell/ps-nvm/blob/master/.docs/reference.md#get-nodeinstalllocation
     #>
     $settings = $null
     $settingsFile = Join-Path $PSScriptRoot 'settings.json'


### PR DESCRIPTION
Adds a script that generates command reference documentation to `.docs/reference.md`, which can also be jumped to with `Get-Help -Online`. Fixed some bugs in the comment blocks to make this work.

The readme now only has a Getting Started guide that shows the most important commands a user will care about - Installing the module, installing node, setting a node version. For everything else, there's a link to the full reference. Plus a few sentences about general features like Semver support and .nvmrc. Removed the big build matrix table in favor of customized badge labels to have the Getting Started guide further at the top.

