### PR TITLE
Improve error handling for prompt use case

### DIFF
--- a/nvm.tests.ps1
+++ b/nvm.tests.ps1
@@ -35,13 +35,11 @@ Describe "Get-NodeVersions" {
 
             }
 
-            It "Throws an error when no versions are installed" {
-                {
-                    $tmpDir = [system.io.path]::GetTempPath()
-                    Mock Get-NodeInstallLocation { Join-Path $tmpDir '.nvm\settings.json' }
-                    Mock Test-Path { return $false }
-                    Get-NodeVersions -Filter 'v8.9.0'
-                } | Should -Throw 'No Node.js versions have been installed'
+            It "Returns nothing when no versions are installed" {
+                $tmpDir = [system.io.path]::GetTempPath()
+                Mock Get-NodeInstallLocation { Join-Path $tmpDir '.nvm\settings.json' }
+                Mock Test-Path { return $false }
+                Get-NodeVersions -Filter 'v8.9.0' | Should -BeNullOrEmpty
             }
         }
 


### PR DESCRIPTION
I put `Set-NodeVersion` in the `prompt` function in $PROFILE to make it always use the Node version specified in package.json of the current folder.

But I noticed that it would print "Switched to Node version x.x.x" after _every_ command, and it would add another entry to the `PATH`, making it grow infinitely.

This makes it not touch the `PATH` if the currently active `node` already resolves to the desired path.