### PR TITLE
Linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ cd .scripts
 dotnet publish -o ..
 cd ..
 
+# Run linting
+Install-Module PSScriptAnalyzer
+Invoke-ScriptAnalyzer ./
+
 # Run tests
 Install-Module Pester
 Invoke-Pester

--- a/nvm.psd1
+++ b/nvm.psd1
@@ -76,7 +76,7 @@
     VariablesToExport      = @()
 
     # Aliases to export from this module
-    AliasesToExport        = @()
+    AliasesToExport        = @("Get-NodeVersion")
 
     # DSC resources to export from this module
     # DscResourcesToExport = @()

--- a/nvm.psm1
+++ b/nvm.psm1
@@ -356,14 +356,14 @@ function Install-NodeVersion {
                 throw "msiexec is not in your path"
             }
 
-            $args = @("/a", "`"$outFile`"", "/qb", "TARGETDIR=`"$unpackPath`"")
+            $argumentList = @("/a", "`"$outFile`"", "/qb", "TARGETDIR=`"$unpackPath`"")
 
             # Make sure to catch any errors since Start-Process doesn't throw based on the process ExitCode
             $result = Start-Process `
                 -FilePath "msiexec.exe" `
                 -Wait `
                 -PassThru `
-                -ArgumentList $args `
+                -ArgumentList $argumentList `
                 -RedirectStandardError "$env:TEMP\stderr.log"
             if ($result.ExitCode -ne 0) {
                 $errMsg = "ExitCode $($result.ExitCode): $(Get-Content "$env:TEMP\stderr.log")"

--- a/nvm.psm1
+++ b/nvm.psm1
@@ -474,6 +474,8 @@ function Get-NodeVersions {
     $versions | Where-Object { $range.IsSatisfied($_) } | Sort-Object -Descending -Property Major, Minor, Patch, PreRelease, Build
 }
 
+Set-Alias Get-NodeVersion Get-NodeVersions
+
 function Set-NodeInstallLocation {
     <#
     .Synopsis
@@ -534,3 +536,5 @@ function Get-NodeInstallLocation {
 
     $settings.InstallPath
 }
+
+Export-ModuleMember -Alias @(Get-NodeVersion)

--- a/nvm.psm1
+++ b/nvm.psm1
@@ -60,8 +60,8 @@ function Set-NodeVersion {
         Set and persist in permanent system path for the machine (Note: requires an admin shell)
     .Link
         https://github.com/aaronpowell/ps-nvm/blob/master/.docs/reference.md/blob/master/.docs/reference.md#set-nodeversion
-    #>
-    [CmdletBinding(DefaultParameterSetName = 'String')]
+#>
+    [CmdletBinding(DefaultParameterSetName = 'String', SupportsShouldProcess)]
     param(
         [string]
         [Parameter(ParameterSetName = 'String', Position = 0, ValueFromPipelineByPropertyName = $true)]
@@ -131,7 +131,7 @@ function Set-NodeVersion {
     $env:NPM_CONFIG_GLOBALCONFIG = (Join-Path $binPath npmrc)
 
     # make the path persistent (only on windows)
-    if ($Persist -ne '') {
+    if ($Persist -ne '' -and $PSCmdlet.ShouldProcess($Version, 'Persist this Node.js version')) {
         if (-not ((IsMac) -or (IsLinux))) {
             $originalPath = [Environment]::GetEnvironmentVariable('PATH', $Persist)
             $cleanedPath = ($originalPath -split $separator | Where-Object { -not $_.StartsWith($nvmPath) }) -join $separator
@@ -400,7 +400,7 @@ function Remove-NodeVersion {
     .Link
         https://github.com/aaronpowell/ps-nvm/blob/master/.docs/reference.md#get-nodeversion
     #>
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [string[]]
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
@@ -417,8 +417,9 @@ function Remove-NodeVersion {
             if (!(Test-Path -Path $requestedVersion)) {
                 throw "Could not find node version $versionNumber"
             }
-
-            Remove-Item $requestedVersion -Force -Recurse
+            if ($PSCmdlet.ShouldProcess($requestedVersion, 'Remove Node.js version from installed versions')) {
+                Remove-Item $requestedVersion -Force -Recurse
+            }
         }
     }
 }
@@ -484,7 +485,7 @@ function Set-NodeInstallLocation {
     .Example
         C:\PS> Set-NodeInstallLocation -Path C:\Temp
     #>
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [string]
         [Parameter(Mandatory = $true)]
@@ -503,7 +504,9 @@ function Set-NodeInstallLocation {
 
     $settings.InstallPath = Join-Path $Path '.nvm'
 
-    ConvertTo-Json $settings | Out-File (Join-Path $PSScriptRoot 'settings.json')
+    if ($PSCmdlet.ShouldProcess($Path, 'Set the Node.js install location')) {
+        ConvertTo-Json $settings | Out-File (Join-Path $PSScriptRoot 'settings.json')
+    }
 }
 
 function Get-NodeInstallLocation {

--- a/nvm.tests.ps1
+++ b/nvm.tests.ps1
@@ -154,7 +154,7 @@ Describe "Install-NodeVersion" {
                     } | ConvertTo-Json
                 }
 
-                { Install-NodeVersion } | Should Throw
+                { Install-NodeVersion } | Should -Throw
             }
 
             It "Will error if no version, no .nvmrc and no package.json, no default" -Skip:($env:include_integration_tests -ne $true) {
@@ -163,7 +163,7 @@ Describe "Install-NodeVersion" {
                 Mock Test-Path -ParameterFilter { $Path -match '.nvmrc$' } { return $false }
                 Mock Test-Path -ParameterFilter { $Path -match 'package.json$' } { return $false }
 
-                { Install-NodeVersion } | Should Throw "Version not given, no .nvmrc found in folder, and package.json missing or does not contain node engines field"
+                { Install-NodeVersion } | Should -Throw -Because "Version not given, no .nvmrc found in folder, and package.json missing or does not contain node engines field"
             }
         }
 
@@ -177,19 +177,19 @@ Describe "Install-NodeVersion" {
 
             It "Throws when version already exists" -Skip:($env:include_integration_tests -ne $true) {
                 Install-NodeVersion -Version 'v9.0.0'
-                { Install-NodeVersion -Version 'v9.0.0' } | Should Throw
+                { Install-NodeVersion -Version 'v9.0.0' } | Should -Throw
             }
 
             It "Won't throw when version already exists if you use the -Force flag" -Skip:($env:include_integration_tests -ne $true) {
-                { Install-NodeVersion -Version 'v9.0.0' -Force } | Should Not Throw
+                { Install-NodeVersion -Version 'v9.0.0' -Force } | Should -Not -Throw
             }
 
             It "Can install without a 'v' prefix" -Skip:($env:include_integration_tests -ne $true) {
-                { Install-NodeVersion -Version '9.0.0' -Force } | Should Not Throw
+                { Install-NodeVersion -Version '9.0.0' -Force } | Should -Not -Throw
             }
 
             It "Can install multiple versions" -Skip:($env:include_integration_tests -ne $true) {
-                { Install-NodeVersion -Version '10.0.0', '11.0.0' } | Should Not Throw
+                { Install-NodeVersion -Version '10.0.0', '11.0.0' } | Should -Not -Throw
             }
         }
 
@@ -312,7 +312,7 @@ Describe "Set-NodeVersion" {
                     } | ConvertTo-Json
                 }
 
-                { Set-NodeVersion } | Should Throw
+                { Set-NodeVersion } | Should -Throw
             }
 
             It "Will error if no version, no .nvmrc and no package.json, no default" {
@@ -321,7 +321,7 @@ Describe "Set-NodeVersion" {
                 Mock Test-Path { return $false } -ParameterFilter { $Path.Contains('.nvmrc') }
                 Mock Test-Path { return $false } -ParameterFilter { $Path.Contains('./package.json') }
 
-                { Set-NodeVersion } | Should Throw "Version not given, no .nvmrc found in folder, and package.json missing or does not contain node engines field"
+                { Set-NodeVersion } | Should -Throw -Because "Version not given, no .nvmrc found in folder, and package.json missing or does not contain node engines field"
             }
         }
 
@@ -352,7 +352,7 @@ Describe "Set-NodeVersion" {
                     Mock Get-NodeVersions { return @() }
 
                     Set-NodeVersion 'v7'
-                } | Should -Throw "No version found that matches v7"
+                } | Should -Throw -Because "No version found that matches v7"
             }
 
             It "Will set npm config path" {
@@ -468,7 +468,7 @@ Describe "Remove-NodeVersion" {
             Mock Remove-Item { }
 
             $version = 'v9.0.0'
- { Remove-NodeVersion $version } | Should -Throw "Could not find node version $version"
+ { Remove-NodeVersion $version } | Should -Throw -Because "Could not find node version $version"
         }
     }
 }


### PR DESCRIPTION
Hello!

I was setting up a PowerShell environment in Linux and I was using your module. I noticed that `Get-NodeVersions` ended in a plural - afaik PowerShell's style guide says that singular nouns are preferred over plural ones even when the command can return multiple things. So, I added an alias so that `Get-NodeVersion` works as well.

I also went ahead and added directions for linting, addressed the most obvious linting issues - this was changing a variable name and adding ShouldProcess support to a few of the cmdlets - and updated the tests to run against Pester 5.

I should note that the tests don't work for me - I get a bunch of errors:

```
PS /home/josh/software/jfhbrook/ps-nvm> Invoke-Pester

Starting discovery in 1 files.
Discovery finished in 65ms.
[-] Set-NodeVersion.auto-discovery.Will set from the .nvmrc file 26ms (25ms|1ms)
 RuntimeException: The variable '$nodeVersion' cannot be retrieved because it has not been set.
 at <ScriptBlock>, /home/josh/software/jfhbrook/ps-nvm/nvm.tests.ps1:266
[-] Set-NodeVersion.auto-discovery.Will set from the default file 32ms (31ms|1ms)
 RuntimeException: Version not given, no .nvmrc found in folder, and package.json missing or does not contain node engines field
 at Get-TargetNodeVersion, /home/josh/software/jfhbrook/ps-nvm/nvm.psm1:173
 at Set-NodeVersion, /home/josh/software/jfhbrook/ps-nvm/nvm.psm1:82
 at <ScriptBlock>, /home/josh/software/jfhbrook/ps-nvm/nvm.tests.ps1:300
[-] Set-NodeVersion.Set from version string.Will set from the supplied version 9ms (8ms|1ms)
 RuntimeException: The variable '$nodeVersion' cannot be retrieved because it has not been set.
 at <ScriptBlock>, /home/josh/software/jfhbrook/ps-nvm/nvm.tests.ps1:332
[-] Set-NodeVersion.Set from version string.Will set from a version range 45ms (44ms|1ms)
 RuntimeException: The variable '$nodeVersion' cannot be retrieved because it has not been set.
 at <ScriptBlock>, /home/josh/software/jfhbrook/ps-nvm/nvm.tests.ps1:340
[-] Set-NodeVersion.Set from version string.Will set from a version range with caret 43ms (42ms|1ms)
 RuntimeException: The variable '$nodeVersion' cannot be retrieved because it has not been set.
 at <ScriptBlock>, /home/josh/software/jfhbrook/ps-nvm/nvm.tests.ps1:347
[-] Set-NodeVersion.pipeline.Will set from the supplied version via Install-NodeVersion pipeline output 19ms (18ms|1ms)
 RuntimeException: The variable '$nodeVersion' cannot be retrieved because it has not been set.
 at <ScriptBlock>, /home/josh/software/jfhbrook/ps-nvm/nvm.tests.ps1:405
[-] Set-NodeVersion.pipeline.Will set from the supplied version via Get-NodeVersion pipeline output 3ms (2ms|1ms)
 RuntimeException: The variable '$nodeVersion' cannot be retrieved because it has not been set.
 at <ScriptBlock>, /home/josh/software/jfhbrook/ps-nvm/nvm.tests.ps1:409
Tests completed in 999ms
Tests Passed: 16, Failed: 7, Skipped: 13 NotRun: 0
```

I get these same errors whether or not I run against master, patch to make tests run against v5 notwithstanding, so I'm fairly certain these changes don't introduce any bugs.

Cheers!