### PR TITLE
Support and try to detect ArmV7L

### DIFF
--- a/nvm.psm1
+++ b/nvm.psm1
@@ -239,7 +239,7 @@ function Install-NodeVersion {
         $Force,
 
         [string]
-        [ValidateSet('Arm', 'Arm64', 'X64', 'X86', 'AMD64')]
+        [ValidateSet('Arm', 'Arm64', 'ArmV7L', 'X64', 'X86', 'AMD64')]
         $Architecture,
 
         [string]
@@ -263,6 +263,13 @@ function Install-NodeVersion {
             }
             else {
                 $Architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+
+                if (Get-Command -Name uname -ErrorAction SilentlyContinue) {
+                    # Architecture may be reported as Arm but might be Armv7L
+                    if ((uname -a) -match 'armv7l') {
+                        $Architecture = 'ArmV7L'
+                    }
+                }
             }
         }
 

--- a/nvm.tests.ps1
+++ b/nvm.tests.ps1
@@ -222,6 +222,30 @@ Describe "Install-NodeVersion" {
             }
         }
 
+        Context "Installing on an ArmV7L system" {
+            It "Can detect if the system architecture is ArmV7L" -Skip:(($env:include_integration_tests -ne $true) -or (-not $IsLinux)) {
+                { Install-NodeVersion -Version '9.0.0' } | Should -Not -Throw
+            }
+
+            BeforeEach {
+                function uname {
+                    Param([switch]$a)
+                    
+                    if ($a) {
+                        return "Linux fake-raspberrypi 4.19.57-v7l+ #1244 SMP Thu Jul 4 18:48:07 BST 2019 armv7l GNU/Linux"
+                    } else {
+                        return "Linux"
+                    }
+                }
+            }
+
+            AfterEach {
+                if (Test-Path Function:uname) {
+                    Remove-Item -Path Function:uname
+                }
+            }
+        }
+
         Context "Incomplete installation" {
             BeforeEach {
                 Mock Get-Command -ParameterFilter { $Name -match 'node' -or $Name -match 'npm' } {


### PR DESCRIPTION
NodeJS releases may not have a Linux distribution marked with the "arm" architecture. For example, the Raspberry Pi 4, which has the "armhf" architecture, must use the "armv7l" release.

This PR adds "ArmV7L" to the list of valid architectures and tries to detect if this is the current architecture.