### PR TITLE
Fix regexp for precise version

### DIFF
--- a/nvm.psm1
+++ b/nvm.psm1
@@ -81,7 +81,7 @@ function Set-NodeVersion {
 
     $Version = Get-TargetNodeVersion($Version).Trim()
 
-    $matchedVersion = if (!($Version -match "v\d+\.\d+\.\d+")) {
+    $matchedVersion = if (!($Version -match "^v\d+\.\d+\.\d+$")) {
         Get-NodeVersions -Filter $Version | Select-Object -First 1
     }
     else {


### PR DESCRIPTION
The regexp for precise versions was missing `^` and `$`, meaning that a range like `^v1.2.3` was also matching the regexp, even though the intention is that only precise versions like `v1.2.3` would match.

This caused faulty paths (including the `^`) to be written into the `PATH` when the package.json contained a range in `engines.node` like `^v1.2.3`.