### PR TITLE
Validate that Set-NodeInstallLocation is an absolute path

### DIFF
--- a/nvm.psm1
+++ b/nvm.psm1
@@ -504,6 +504,10 @@ function Set-NodeInstallLocation {
         This is used to override the default node.js install path for nvm, which is relative to the module install location. You would want to use this to get around the Windows path limit problem that plagues node.js installed. Note that to avoid collisions the unpacked files will be in a folder `.nvm\<version>` in the specified location.
     .Parameter Path
         The root folder for nvm.  Path must be absolute.
+    .Parameter Confirm
+        Prompts you for confirmation before running the cmdlet.
+    .Parameter WhatIf
+        Shows what would happen if the cmdlet runs. The cmdlet is not run.
     .Example
         C:\PS> Set-NodeInstallLocation -Path C:\Temp
     #>

--- a/nvm.psm1
+++ b/nvm.psm1
@@ -507,7 +507,7 @@ function Set-NodeInstallLocation {
     .Example
         C:\PS> Set-NodeInstallLocation -Path C:\Temp
     #>
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [string]
         [Parameter(Mandatory = $true)]
@@ -515,17 +515,23 @@ function Set-NodeInstallLocation {
         $Path
     )
 
+    $installPath = Join-Path $Path '.nvm'
+
+    if (!$PSCmdlet.ShouldProcess("Path: ${installPath}", "Set Node install location")) {
+        return
+    }
+
     $settings = $null
     $settingsFile = Join-Path $PSScriptRoot 'settings.json'
 
     if ((Test-Path $settingsFile) -eq $true) {
         $settings = Get-Content $settingsFile | ConvertFrom-Json
+        $settings.InstallPath = $installPath
     }
     else {
-        $settings = @{ 'InstallPath' = Get-NodeInstallLocation }
+        $settings = @{ 'InstallPath' = $installPath }
     }
 
-    $settings.InstallPath = Join-Path $Path '.nvm'
 
     ConvertTo-Json $settings | Out-File (Join-Path $PSScriptRoot 'settings.json')
 }

--- a/nvm.psm1
+++ b/nvm.psm1
@@ -22,6 +22,16 @@ function IsWindows() {
     return (Test-Path variable:global:IsWindows) -and $IsWindows
 }
 
+function IsAbsolutePath([string] $Path) {
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+        # PowerShell 5.x doesn't have IsPathFullyQualified.
+        # IsPathRooted is the best we can do here.
+        return [IO.Path]::IsPathRooted($Path)
+    }
+
+    return [IO.Path]::IsPathFullyQualified($Path)
+}
+
 function Set-NodeVersion {
     <#
     .Synopsis
@@ -493,7 +503,7 @@ function Set-NodeInstallLocation {
     .Description
         This is used to override the default node.js install path for nvm, which is relative to the module install location. You would want to use this to get around the Windows path limit problem that plagues node.js installed. Note that to avoid collisions the unpacked files will be in a folder `.nvm\<version>` in the specified location.
     .Parameter Path
-        The root folder for nvm
+        The root folder for nvm.  Path must be absolute.
     .Example
         C:\PS> Set-NodeInstallLocation -Path C:\Temp
     #>
@@ -501,6 +511,7 @@ function Set-NodeInstallLocation {
     param(
         [string]
         [Parameter(Mandatory = $true)]
+        [ValidateScript({ IsAbsolutePath($_) })]
         $Path
     )
 


### PR DESCRIPTION
This comes after I have lazily typed `Set-Node<tab> 18` and found my installation path changed to `18\.nvm` one too many times.

I have also added ShouldProcess support to `Set-NodeInstallLocation` so it can accept the `-WhatIf` and `-Confirm` parameters.  (I plan on adding a [default parameter value](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_parameters_default_values?view=powershell-7.3) in my profile.ps1 to require confirmation, which should stop me from accidentally doing this again.

## Known issues

- Error message isn't the best it could be.  Unfortunately [ValidateScript.ErrorMessage](https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.validatescriptattribute.errormessage?view=powershellsdk-7.3.0) is only in PowerShell 7.2 and later.
- The path validation in PowerShell 5.1 is limited to the [IsPathRooted](https://learn.microsoft.com/en-us/dotnet/api/system.io.path.ispathrooted) function, which technically allows paths to the relative directory for the working drive (e.g., `C:temp` would be `C:\users\myuser\temp` if the current location was `C:\users\myuser`.
