### PR TITLE
Fix Windows MSI unpack path detection for Node.js v22

### DIFF
--- a/nvm.psd1
+++ b/nvm.psd1
@@ -12,7 +12,7 @@
     RootModule             = 'nvm.psm1'
 
     # Version number of this module.
-    ModuleVersion          = '2.5.4'
+    ModuleVersion          = '2.5.5'
 
     # ID used to uniquely identify this module
     GUID                   = 'cb931787-e31c-454a-88e3-1c0c201e1e2d'
@@ -125,4 +125,3 @@
     # DefaultCommandPrefix = ''
 
 }
-

--- a/nvm.psm1
+++ b/nvm.psm1
@@ -32,6 +32,28 @@ function IsAbsolutePath([string] $Path) {
     return [IO.Path]::IsPathFullyQualified($Path)
 }
 
+function Resolve-WindowsNodeInstallPathFromMsi([string] $UnpackPath) {
+    $possiblePaths = @('PFiles64/nodejs', 'PFiles/nodejs', 'nodejs')
+    foreach ($path in $possiblePaths) {
+        $candidatePath = Join-Path $UnpackPath $path
+        if (Test-Path (Join-Path $candidatePath 'node.exe')) {
+            return $candidatePath
+        }
+    }
+
+    $candidates = @(Get-ChildItem -Path $UnpackPath -Filter 'node.exe' -File -Recurse | ForEach-Object { $_.DirectoryName } | Select-Object -Unique)
+    if ($candidates.Count -eq 0) {
+        throw "Could not find nodejs install path"
+    }
+
+    $preferredCandidate = $candidates | Where-Object { Test-Path (Join-Path $_ 'npm.cmd') } | Select-Object -First 1
+    if ($null -ne $preferredCandidate) {
+        return $preferredCandidate
+    }
+
+    return ($candidates | Select-Object -First 1)
+}
+
 function Set-NodeVersion {
     <#
     .Synopsis
@@ -381,18 +403,7 @@ function Install-NodeVersion {
                 throw $errMsg
             }
 
-            $possiblePaths = @('PFiles64/nodejs', 'PFiles/nodejs', 'nodejs')
-            $expectedPath = $null
-            foreach ($path in $possiblePaths) {
-                $expectedPath = Join-Path $unpackPath $path
-                if (Test-Path $expectedPath) {
-                    break
-                }
-            }
-
-            if (-Not (Test-Path $expectedPath)) {
-                throw "Could not find nodejs install path"
-            }
+            $expectedPath = Resolve-WindowsNodeInstallPathFromMsi -UnpackPath $unpackPath
 
             Move-Item (Join-Path ($expectedPath) '*') -Destination $versionPath -Force
 

--- a/nvm.tests.ps1
+++ b/nvm.tests.ps1
@@ -112,6 +112,51 @@ Describe "Get-NodeInstallLocation" {
     }
 }
 
+Describe "Resolve-WindowsNodeInstallPathFromMsi" {
+    InModuleScope nvm {
+        It "Finds legacy expected install path" {
+            $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+            $nodeDir = Join-Path $tmpDir 'PFiles64\nodejs'
+            New-Item -Path $nodeDir -ItemType Directory -Force | Out-Null
+            New-Item -Path (Join-Path $nodeDir 'node.exe') -ItemType File | Out-Null
+
+            try {
+                Resolve-WindowsNodeInstallPathFromMsi -UnpackPath $tmpDir | Should -Be $nodeDir
+            }
+            finally {
+                Remove-Item $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        It "Falls back to locating node.exe recursively for new layouts" {
+            $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+            $nodeDir = Join-Path $tmpDir 'Files\node-runtime'
+            New-Item -Path $nodeDir -ItemType Directory -Force | Out-Null
+            New-Item -Path (Join-Path $nodeDir 'node.exe') -ItemType File | Out-Null
+            New-Item -Path (Join-Path $nodeDir 'npm.cmd') -ItemType File | Out-Null
+
+            try {
+                Resolve-WindowsNodeInstallPathFromMsi -UnpackPath $tmpDir | Should -Be $nodeDir
+            }
+            finally {
+                Remove-Item $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        It "Throws when node.exe cannot be found" {
+            $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+            New-Item -Path $tmpDir -ItemType Directory -Force | Out-Null
+
+            try {
+                { Resolve-WindowsNodeInstallPathFromMsi -UnpackPath $tmpDir } | Should -Throw "Could not find nodejs install path"
+            }
+            finally {
+                Remove-Item $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}
+
 Describe "Install-NodeVersion" {
     InModuleScope nvm {
         Context "auto-discovery" {


### PR DESCRIPTION
Node.js v22 MSI installs can place files in layouts that do not always match the previously hardcoded directories. This caused install failures when `ps-nvm` could not find the unpacked `node.exe` path.

## What changed
- Added `Resolve-WindowsNodeInstallPathFromMsi` to locate the Node install root more robustly.
- Kept support for legacy known MSI paths first (`PFiles64/nodejs`, `PFiles/nodejs`, `nodejs`).
- Added a recursive fallback that finds `node.exe` and prefers a directory containing `npm.cmd` when multiple candidates are present.
- Updated `Install-NodeVersion` to use the new resolver.

## Tests
- Added unit tests for:
  - legacy expected MSI path resolution
  - fallback recursive path resolution for new layouts
  - explicit failure when no `node.exe` is found

This keeps existing behavior for older installers while making Windows installs resilient to MSI structure changes in newer Node releases.